### PR TITLE
Fix a bug in abort() and improve error wrapping

### DIFF
--- a/lib/protocol/errors.js
+++ b/lib/protocol/errors.js
@@ -25,7 +25,11 @@ var rfc = [
 
 var errors = {
 	wrap: function (message){
-		return { code: 0, name: null, message: message }
+		var code = 0;
+		for (var name in this)
+			if (this[name].message === message)
+				code = this[name].code
+		return { code: code, name: null, message: message }
 	}
 };
 

--- a/lib/protocol/request.js
+++ b/lib/protocol/request.js
@@ -33,8 +33,8 @@ var Request = module.exports = function (address, port, retries,
 Request.prototype.abort = function (error){
 	if (this._closed || this._closing || this._aborted) return;
 	this._aborted = true;
-	this._send (packets.error.serialize (normalizeError (error)));
-	this._close ();
+	var me = this;
+	this._send (packets.error.serialize (normalizeError (error)), function() { me._close () });
 };
 
 Request.prototype.close = function (){
@@ -113,9 +113,9 @@ Request.prototype._sendAndRetransmit = function (buffer){
 	});
 };
 
-Request.prototype._send = function (buffer){
+Request.prototype._send = function (buffer, cb){
 	if (this._closed || this._closing) return;
-	this._socket.send (buffer, 0, buffer.length, this._port, this._address);
+	this._socket.send (buffer, 0, buffer.length, this._port, this._address, cb);
 };
 
 Request.prototype._createRetransmitter = function (){


### PR DESCRIPTION
* Fix a bug in Request.abort() where the socket gets closed before
  the error packet is sent.
* Improve error wrapping by setting the code when the message
  matches one of the predefined strings.