### PR TITLE
Check tsize option in request extension

### DIFF
--- a/lib/protocol/server/incoming-request.js
+++ b/lib/protocol/server/incoming-request.js
@@ -65,7 +65,9 @@ IncomingRequest.prototype.continueRequest = function (size){
 	if (this._requestExtensions === null){
 		this.onContinue ();
 	}else{
-		this._responseExtensions.tsize = size;
+        if( this._responseExtensions.tsize !== undefined){
+            this._responseExtensions.tsize = size;
+        }
 		
 		//Set the user extensions
 		for (var p in this._responseUserExtensions){
@@ -163,6 +165,7 @@ IncomingRequest.prototype._sendOackMessage = function (extensions){
 	}
 	if (extensions.tsize !== undefined){
 		if (!this._isRRQ) this._size = extensions.tsize;
+		ext.tsize = extensions.tsize;
 		//ext.tsize is set later, when the request continues (RRQ)
 	}
 	if (extensions.rollover !== undefined){


### PR DESCRIPTION
- tsize option set in the response extension when not requested.
  EFI PXE client sends mal-formatted OACK error when this option is sent unexpectedly in the response.