### PR TITLE
Validate PutStream.setSize() to ease debugging

### DIFF
--- a/lib/streams/server/put-stream.js
+++ b/lib/streams/server/put-stream.js
@@ -123,6 +123,9 @@ PutStream.prototype._write = function (chunk, encoding, cb){
 };
 
 PutStream.prototype.setSize = function (size){
+	// !() because it could be NaN, or a string which needs automatic casting)
+	if (!(size >= 0)) throw new Error ("The file size must be >= 0 and of type Number.");
+	
 	if (this._isWRQ) throw new Error ("Only GET requests can set the size");
 	//Sanity check
 	if (this._gs._aborted) return;


### PR DESCRIPTION
This check will save time for others in the future.

Took me an entire to debug a NaN size sent to PutStream.setSize(). 
The server was even responding with a partial Buffer contents.

I was reading non-existing Content-Length from some HTTP response and then doing parseInt on it.