### PR TITLE
Fixed. TFTP server recovers after packet loss

### DIFF
--- a/lib/protocol/writer.js
+++ b/lib/protocol/writer.js
@@ -211,10 +211,10 @@ Window.prototype.resume = function (block){
 	//Ignore invalid acks (duplicates included) only when the window doesn't
 	//rollover
 	if (!this._mayRollover &&
-			(block < this._start - 1 || block > this._end)) return;
+			(block < this._start || block > this._end)) return;
 
 	if (this._mayRollover &&
-                        (block < this._start - 1 && block > this._end)) return;	
+                        (block < this._start  && block > this._end)) return;	
 	
 	this._writerTimer.reset ();
 	

--- a/lib/protocol/writer.js
+++ b/lib/protocol/writer.js
@@ -212,42 +212,48 @@ Window.prototype.resume = function (block){
 	//rollover
 	if (!this._mayRollover &&
 			(block < this._start - 1 || block > this._end)) return;
+
+	if (this._mayRollover &&
+                        (block < this._start - 1 && block > this._end)) return;	
 	
 	this._writerTimer.reset ();
 	
 	if (block !== this._end){
 		//Not all the blocks has been received in the server
-		if (block === this._start - 1){
-			//The whole window must be send again
-			this._writerTimer.start (this._restransmitterSendFn);
-			this._blocks.forEach (this._sendFn);
-		}else{
-			//Remove the blocks already received and shift the window
-			while (this._blocks[0].block !== block){
-				this._blocks.shift ();
-			}
-			this._blocks.shift ();
-		}
-	}else{
+		
+		while  ( ((this._blocks[0].block <= block) || 
+				(this._mayRollover && (this._blocks[0].block >= block))) &&
+			 	(this._blocks.length  >1)){
+                             this._blocks.shift ();
+                     }
+	}else
+	{ 
 		this._blocks = [];
 	}
-	
+	 this._start = block  + 1;	
 	//Update the window
-	this._start = this._block + 1;
 	if (this._start === 65536){
 		this._start = this._rollover;
+		this._mayRollover = false;
 	}else{
 		this._mayRollover = true;
 	}
-	this._end = this._block + this._windowSize;
+	this._end = block + this._windowSize;
 	if (this._end > 65535){
-		this._end -= 65535 + this._rolloverFix;
+		this._end -= 65536 + this._rollover;
 	}else{
 		this._mayRollover = false;
 	}
 	
-	this._pending = this._windowSize;
+	this._pending = this._windowSize - this._blocks.length;
 	var cb = this._cb;
-	this._cb = null;
-	cb ();
+	if (this._pending) {
+		this._cb = null;
+		cb ();
+	}
+	else {
+		this._writerTimer.start (this._restransmitterSendFn);
+		this._blocks.forEach (this._sendFn);	
+	
+	}
 };


### PR DESCRIPTION
After one packet is lost, the TFTP server must send the next block, but it is sending the last acknolodged block causing a loop and timeout on the client side.

![image](https://user-images.githubusercontent.com/46055545/100739878-8d24dd80-33b6-11eb-834c-9842148b1f9c.png)

![image](https://user-images.githubusercontent.com/46055545/100744506-b5afd600-33bc-11eb-8eb3-4d0494377736.png)


Testing toos: 
https://github.com/ClausKlein/tftp-hpa.git

Forcing packet loss:
tc qdisc add dev eth0 root netem loss 3%
